### PR TITLE
indexPathForItem fix

### DIFF
--- a/RATreeView/RATreeView/Private Files/RATreeNodeController.m
+++ b/RATreeView/RATreeView/Private Files/RATreeNodeController.m
@@ -176,15 +176,23 @@
   [self.treeNode setExpanded:NO];
   [self invalidate];
   
-  if (collapseChildren) {
-    for (RATreeNodeController *controller in self.childControllers) {
-      [controller collapseAndCollapseChildren:collapseChildren];
-    }
-  }
-  
+  [self invalidateAndColapseChildren:collapseChildren];
+
   [self.parentController invalidateTreeNodesAfterChildAtIndex:[self.parentController.childControllers indexOfObject:self]];
 }
 
+- (void)invalidateAndColapseChildren:(BOOL)collapseChildren
+{
+    if (collapseChildren)
+    {
+        [self.treeNode setExpanded:NO];
+    }
+    [self invalidate];
+
+    for (RATreeNodeController *controller in self.childControllers) {
+        [controller invalidateAndColapseChildren:collapseChildren];
+    }
+}
 
 #pragma mark -
 


### PR DESCRIPTION
After expand and collapse a cell I have an issue with cellForItem: for its child cells. After cell is collapsed without collapseChildren option, child cells are not invalidated, and indexPathForItem: returns valid indexPath, so cellForItem: returns incorrect cell (one from below).
This caused a lot of unexpected behavior.

This is the simplest solution: still assingsetExpanded:NO only in case it is expected, but invalidate all hierarchy of children every time.